### PR TITLE
fix arguments for _on_ws_close

### DIFF
--- a/c8ydp/device_proxy.py
+++ b/c8ydp/device_proxy.py
@@ -232,7 +232,7 @@ class DeviceProxy:
         # See https://stackoverflow.com/questions/26980966/using-a-websocket-client-as-a-class-in-python
         web_socket.on_message = lambda ws, msg: self._on_ws_message(ws, msg)
         web_socket.on_error = lambda ws, error: self._on_ws_error(ws, error)
-        web_socket.on_close = lambda ws: self._on_ws_close(ws)
+        web_socket.on_close = lambda ws, status, reason: self._on_ws_close(ws, status, reason)
         web_socket.on_open = lambda ws: self._on_ws_open(ws)
         self.logger.info(f'Starting Web Socket Connection...')
         self._web_socket = web_socket


### PR DESCRIPTION
follow-up of https://github.com/SoftwareAG/cumulocity-remote-access-agent/commit/60deee69705ad01b0eb3da8f95f9e599646f25b8

Prior to this change, remote access fails with the error below:
```
2021-09-03 07:16:22,029 WSTunnelThread-89435382 ERROR websocket error from callback <function DeviceProxy._websocket_connect.<locals>.<lambda> at 0x7f89d5b97d08>: <lambda>() takes 1 positional argument but 3 were given
```